### PR TITLE
Fix logger imports

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - LOGIN API CON SUPABASE
 // ================================================================
 // Versione: 2.0.0

--- a/api/ping.js
+++ b/api/ping.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - PING API CON TEST COMPLETI
 // ================================================================
 // Versione: 3.0.0

--- a/api/register.js
+++ b/api/register.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - REGISTER API CON SUPABASE
 // ================================================================
 // Versione: 2.0.0

--- a/api/supabase.js
+++ b/api/supabase.js
@@ -9,7 +9,7 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require('../logger.js');
+import { log, debug, info, warn, error } from '../logger.js';
 
 // ================================================================
 // CONFIGURAZIONE SUPABASE

--- a/api/ucme.js
+++ b/api/ucme.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - UCME API CON SUPABASE
 // ================================================================
 // Versione: 2.0.0

--- a/api/ucmes.js
+++ b/api/ucmes.js
@@ -1,18 +1,15 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - API UCMES (CARICAMENTO)
 // ================================================================
 // Endpoint per recuperare UCMe salvate nel database Supabase
 
-import { 
-  verifyJWT, 
-  getUserUCMes, 
+import {
+  verifyJWT,
+  getUserUCMes,
   testDatabaseConnection
 } from './supabase.js';
-
-// Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require('../logger.js');
 
 export default async function handler(req, res) {
   debug('🟣 ============================================');

--- a/api/users.js
+++ b/api/users.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - API UTENTI
 // ================================================================
 // Endpoint per recuperare tutti gli utenti dal database e aggiornare profili

--- a/api/validate-token.js
+++ b/api/validate-token.js
@@ -1,6 +1,6 @@
 // ================================================================
 // Sistema di logging per ambiente produzione
-const { log, debug, info, warn, error } = require("../logger.js");
+import { log, debug, info, warn, error } from '../logger.js';
 // MENTAL COMMONS - TOKEN VALIDATION API
 // ================================================================
 // Versione: 1.0.0


### PR DESCRIPTION
## Summary
- switch API modules to ESM `import` syntax for logger

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68581282acfc83249145a15297855b0d